### PR TITLE
Fix horizontal scroll caused by pagination on narrow viewports

### DIFF
--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -1,25 +1,58 @@
 {% if paginator.total_pages > 1 %}
+{% assign cur = paginator.page %}
+{% assign total = paginator.total_pages %}
+{% assign window = 1 %}
+{% assign w_start = cur | minus: window %}
+{% assign w_end = cur | plus: window %}
+{% if w_start < 2 %}{% assign w_start = 2 %}{% endif %}
+{% if w_end > total | minus: 1 %}{% assign w_end = total | minus: 1 %}{% endif %}
+
 <nav class="pagination" aria-label="페이지 네비게이션">
   {% if paginator.previous_page %}
-    <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}" rel="prev" aria-label="이전 페이지">‹ 이전</a>
+    <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}" rel="prev" aria-label="이전 페이지">‹</a>
   {% else %}
-    <span class="disabled">‹ 이전</span>
+    <span class="disabled">‹</span>
   {% endif %}
 
-  {% for page in (1..paginator.total_pages) %}
-    {% if page == paginator.page %}
+  {% comment %} First page {% endcomment %}
+  {% if cur == 1 %}
+    <span class="current" aria-current="page">1</span>
+  {% else %}
+    <a href="{{ '/' | prepend: site.baseurl | replace: '//', '/' }}">1</a>
+  {% endif %}
+
+  {% comment %} Left ellipsis {% endcomment %}
+  {% if w_start > 2 %}
+    <span class="ellipsis">…</span>
+  {% endif %}
+
+  {% comment %} Window of pages around current {% endcomment %}
+  {% for page in (w_start..w_end) %}
+    {% if page == cur %}
       <span class="current" aria-current="page">{{ page }}</span>
-    {% elsif page == 1 %}
-      <a href="{{ '/' | prepend: site.baseurl | replace: '//', '/' }}">{{ page }}</a>
     {% else %}
       <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}">{{ page }}</a>
     {% endif %}
   {% endfor %}
 
+  {% comment %} Right ellipsis {% endcomment %}
+  {% if w_end < total | minus: 1 %}
+    <span class="ellipsis">…</span>
+  {% endif %}
+
+  {% comment %} Last page {% endcomment %}
+  {% if total > 1 %}
+    {% if cur == total %}
+      <span class="current" aria-current="page">{{ total }}</span>
+    {% else %}
+      <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', total }}">{{ total }}</a>
+    {% endif %}
+  {% endif %}
+
   {% if paginator.next_page %}
-    <a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}" rel="next" aria-label="다음 페이지">다음 ›</a>
+    <a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}" rel="next" aria-label="다음 페이지">›</a>
   {% else %}
-    <span class="disabled">다음 ›</span>
+    <span class="disabled">›</span>
   {% endif %}
 </nav>
 {% endif %}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -57,7 +57,10 @@
    ========================================================= */
 *, *::before, *::after { box-sizing: border-box; }
 
-html { -webkit-text-size-adjust: 100%; }
+html {
+  -webkit-text-size-adjust: 100%;
+  overflow-x: hidden;
+}
 
 body {
   margin: 0;
@@ -69,6 +72,7 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   transition: background-color 0.2s ease, color 0.2s ease;
+  overflow-x: hidden;
 }
 
 img, svg, video { max-width: 100%; height: auto; display: block; }
@@ -436,10 +440,13 @@ pre code {
    ========================================================= */
 .pagination {
   display: flex;
+  flex-wrap: wrap;
   justify-content: center;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   margin: 50px 0 0;
+  max-width: 100%;
+  padding: 0 4px;
 }
 .pagination a, .pagination span {
   padding: 8px 14px;
@@ -448,6 +455,9 @@ pre code {
   color: var(--text-soft);
   border: 1px solid var(--border);
   background: var(--bg);
+  min-width: 40px;
+  text-align: center;
+  white-space: nowrap;
 }
 .pagination a:hover {
   background: var(--bg-elev);
@@ -460,6 +470,21 @@ pre code {
   border-color: var(--accent);
 }
 .pagination .disabled { opacity: 0.4; }
+.pagination .ellipsis {
+  border: 0;
+  background: transparent;
+  padding: 8px 4px;
+  min-width: auto;
+  color: var(--text-muted);
+}
+
+@media (max-width: 480px) {
+  .pagination a, .pagination span {
+    padding: 7px 10px;
+    font-size: 0.88rem;
+    min-width: 34px;
+  }
+}
 
 /* =========================================================
    Page (about, contact, privacy, etc)


### PR DESCRIPTION
## Summary

64개 글 / 11페이지 기준에서 페이지네이션 버튼이 가로 한 줄에 다 깔려 모바일에서 가로 스크롤이 발생하던 문제 수정.

### 변경 내용
- 페이지 번호를 **첫 페이지 + (현재 ±1) + 마지막 페이지 + 말줄임표**로 압축
- `flex-wrap: wrap` 추가로 좁은 화면에서 자연스럽게 줄바꿈
- 480px 이하 미디어쿼리로 버튼 패딩/폰트 축소
- `html`, `body`에 `overflow-x: hidden` 백스톱 추가 (다른 요소가 가로 스크롤 유발하지 못하게)

## Test plan
- [ ] 데스크탑에서 페이지 번호가 `‹ 1 … 4 5 6 … 11 ›` 형태로 표시되는지
- [ ] 모바일(360~480px)에서 가로 스크롤 사라졌는지
- [ ] 페이지 이동 정상 작동하는지

---
_Generated by [Claude Code](https://claude.ai/code/session_01LF1EU4iJTskuyeJjmGLvVP)_