### PR TITLE
Fix pagination duplicate last page and broken reading progress bar

### DIFF
--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -2,10 +2,11 @@
 {% assign cur = paginator.page %}
 {% assign total = paginator.total_pages %}
 {% assign window = 1 %}
+{% assign max_w_end = total | minus: 1 %}
 {% assign w_start = cur | minus: window %}
 {% assign w_end = cur | plus: window %}
 {% if w_start < 2 %}{% assign w_start = 2 %}{% endif %}
-{% if w_end > total | minus: 1 %}{% assign w_end = total | minus: 1 %}{% endif %}
+{% if w_end > max_w_end %}{% assign w_end = max_w_end %}{% endif %}
 
 <nav class="pagination" aria-label="페이지 네비게이션">
   {% if paginator.previous_page %}
@@ -26,21 +27,23 @@
     <span class="ellipsis">…</span>
   {% endif %}
 
-  {% comment %} Window of pages around current {% endcomment %}
-  {% for page in (w_start..w_end) %}
-    {% if page == cur %}
-      <span class="current" aria-current="page">{{ page }}</span>
-    {% else %}
-      <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}">{{ page }}</a>
-    {% endif %}
-  {% endfor %}
+  {% comment %} Window of pages around current (excludes 1 and total) {% endcomment %}
+  {% if w_end >= w_start %}
+    {% for page in (w_start..w_end) %}
+      {% if page == cur %}
+        <span class="current" aria-current="page">{{ page }}</span>
+      {% else %}
+        <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}">{{ page }}</a>
+      {% endif %}
+    {% endfor %}
+  {% endif %}
 
   {% comment %} Right ellipsis {% endcomment %}
-  {% if w_end < total | minus: 1 %}
+  {% if w_end < max_w_end %}
     <span class="ellipsis">…</span>
   {% endif %}
 
-  {% comment %} Last page {% endcomment %}
+  {% comment %} Last page (only if different from first) {% endcomment %}
   {% if total > 1 %}
     {% if cur == total %}
       <span class="current" aria-current="page">{{ total }}</span>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -59,7 +59,6 @@
 
 html {
   -webkit-text-size-adjust: 100%;
-  overflow-x: hidden;
 }
 
 body {
@@ -72,7 +71,7 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   transition: background-color 0.2s ease, color 0.2s ease;
-  overflow-x: hidden;
+  overflow-x: clip;
 }
 
 img, svg, video { max-width: 100%; height: auto; display: block; }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -61,15 +61,31 @@
   // -----------------------------
   var progressEl = document.getElementById('reading-progress');
   if (progressEl) {
+    var ticking = false;
     var update = function () {
       var doc = document.documentElement;
-      var scrollTop = window.scrollY || doc.scrollTop;
-      var height = doc.scrollHeight - doc.clientHeight;
-      var pct = height > 0 ? (scrollTop / height) * 100 : 0;
+      var body = document.body;
+      var scrollTop = window.pageYOffset || doc.scrollTop || body.scrollTop || 0;
+      var docHeight = Math.max(
+        body.scrollHeight, doc.scrollHeight,
+        body.offsetHeight, doc.offsetHeight
+      );
+      var winHeight = window.innerHeight || doc.clientHeight;
+      var trackable = docHeight - winHeight;
+      var pct = trackable > 0 ? (scrollTop / trackable) * 100 : 0;
+      if (pct < 0) pct = 0;
+      if (pct > 100) pct = 100;
       progressEl.style.width = pct + '%';
+      ticking = false;
     };
-    window.addEventListener('scroll', update, { passive: true });
-    window.addEventListener('resize', update);
+    var onScroll = function () {
+      if (!ticking) {
+        window.requestAnimationFrame(update);
+        ticking = true;
+      }
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll);
     update();
   }
 


### PR DESCRIPTION
## Summary

연이어 보고된 두 버그를 한 번에 수정.

### 1. 페이지네이션에 마지막 번호가 두 번 표시되던 문제
- `{% if w_end > total | minus: 1 %}` 형태의 Liquid 비교가 필터 우선순위 때문에 의도대로 평가되지 않아 윈도우 캡이 적용되지 않았고, 결과적으로 **마지막 페이지(예: 11)가 윈도우 안에 한 번 + 마지막 앵커로 한 번** 두 번 출력되었음
- `total - 1`을 변수(`max_w_end`)로 미리 계산해서 비교에 사용하도록 변경
- 윈도우 범위가 역전될 수 있는 경계값에서 `w_end >= w_start` 가드 추가

### 2. 읽기 진행률 바가 스크롤해도 변하지 않던 문제
- 직전 커밋에서 가로 스크롤 백스톱으로 추가한 `html { overflow-x: hidden }`이 `position: fixed` 컨테이닝 블록을 viewport에서 부모로 옮겨버려 진행률 바가 작동하지 않았음
- `html`에서는 `overflow-x` 제거, `body`만 `overflow-x: clip` (스크롤 컨테이너를 만들지 않는 형태)으로 변경
- 진행률 계산 JS도 보강: `pageYOffset` 사용, body/documentElement 최댓값 기준, 0~100 클램프, requestAnimationFrame 쓰로틀

## Test plan
- [ ] 홈 페이지 하단에서 `‹ 1 … 4 5 6 … 11 ›` 형태로 표시되고 11이 한 번만 나오는지
- [ ] 마지막 페이지(11)에 진입했을 때 `‹ 1 … 10 [11] ›` 형태인지
- [ ] 글 페이지에서 스크롤하면 상단 진행률 바가 0%→100%로 자연스럽게 차오르는지
- [ ] 모바일에서 가로 스크롤이 다시 생기지 않는지

---
_Generated by [Claude Code](https://claude.ai/code/session_01LF1EU4iJTskuyeJjmGLvVP)_