### PR TITLE
Collapse in-post ad slot while AdSense is unfilled

### DIFF
--- a/_includes/adsense-under-header.html
+++ b/_includes/adsense-under-header.html
@@ -1,4 +1,3 @@
-<!-- Under Header Ad Unit -->
 <ins class="adsbygoogle"
     style="display:block"
     data-ad-client="{{ site.adsense-data-ad-client }}"
@@ -8,4 +7,3 @@
 <script>
 (adsbygoogle = window.adsbygoogle || []).push({});
 </script>
-<br/>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -657,21 +657,17 @@ pre code {
 }
 #comments { display: none; margin-top: 16px; }
 
-/* Ad slot */
+/* Ad slot — collapses to ~0 height when AdSense doesn't fill */
 .ad-slot {
-  margin: 24px 0;
-  padding: 8px 0;
+  margin: 0;
   text-align: center;
-  min-height: 100px;
 }
-.ad-slot::before {
-  content: 'Advertisement';
-  display: block;
-  font-size: 0.7rem;
-  color: var(--text-muted);
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  margin-bottom: 8px;
+.ad-slot ins.adsbygoogle[data-ad-status="unfilled"],
+.ad-slot ins.adsbygoogle:empty {
+  display: none !important;
+}
+.ad-slot:has(ins[data-ad-status="filled"]) {
+  margin: 24px 0;
 }
 
 /* =========================================================


### PR DESCRIPTION
## Summary

글 페이지 상단 광고 영역이 광고가 채워지지 않았는데도 큰 빈 공간을 차지하던 문제 수정.

### 원인
`.ad-slot`에 `min-height: 100px`, `padding`, `::before "Advertisement"` 라벨이 있었고 include 끝에 `<br>`까지 있어 총 150px 가까운 빈 영역이 모든 글 상단에 고정 표시됨.

### 수정
- `min-height`, 라벨, `<br>` 제거
- `ins.adsbygoogle[data-ad-status="unfilled"]`와 비어있는 `<ins>`는 `display: none`
- 실제 광고가 fill됐을 때만 `:has(ins[data-ad-status="filled"])`로 vertical margin 부여

## Test plan
- [ ] 글 페이지 상단의 큰 빈 공간이 사라졌는지
- [ ] 향후 AdSense 활성화 시 채워진 광고 위아래 간격이 자연스럽게 살아나는지

---
_Generated by [Claude Code](https://claude.ai/code/session_01LF1EU4iJTskuyeJjmGLvVP)_