### PR TITLE
Fix header icons hugging the left edge on mobile

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -181,13 +181,15 @@ pre code {
   position: sticky;
   top: 0;
   z-index: 100;
-  background: rgba(255, 255, 255, 0.85);
+  background: rgba(255, 255, 255, 0.92);
   backdrop-filter: saturate(180%) blur(12px);
   -webkit-backdrop-filter: saturate(180%) blur(12px);
   border-bottom: 1px solid var(--border);
+  box-shadow: 0 1px 0 rgba(15, 23, 42, 0.02);
 }
 [data-theme="dark"] .site-header {
-  background: rgba(15, 17, 21, 0.8);
+  background: rgba(15, 17, 21, 0.85);
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.4);
 }
 
 .header-inner {
@@ -201,6 +203,7 @@ pre code {
   display: inline-flex;
   align-items: center;
   gap: 10px;
+  margin-right: auto;
   font-weight: 700;
   font-size: 1.05rem;
   color: var(--text);
@@ -220,7 +223,6 @@ pre code {
 .primary-nav {
   display: flex;
   gap: 4px;
-  margin-left: auto;
 }
 .primary-nav a {
   padding: 8px 12px;
@@ -662,6 +664,7 @@ pre code {
   margin: 0;
   text-align: center;
 }
+.ad-slot::before { content: none !important; }
 .ad-slot ins.adsbygoogle[data-ad-status="unfilled"],
 .ad-slot ins.adsbygoogle:empty {
   display: none !important;


### PR DESCRIPTION
## Summary

모바일 헤더에서 검색/테마/메뉴 아이콘 3개가 브랜드 옆에 좌측 몰림 현상 + 광고 라벨 잔존 가능성 차단.

### 수정
- `.brand`에 `margin-right: auto`를 부여해 nav 노출 여부와 무관하게 항상 우측으로 푸시
- `.primary-nav`의 `margin-left: auto` 제거 (이제 brand 한 곳에서 관리)
- 헤더 배경 불투명도/그림자 미세 보강 (흰 배경 위에서 가독성)
- `.ad-slot::before`에 `content: none !important` 백스톱 (혹시 다른 규칙이 라벨 부활시키지 못하게)

## Test plan
- [ ] 모바일 360~480px에서 헤더 아이콘이 우측 끝으로 붙는지
- [ ] 데스크탑에서 brand 좌측, nav+actions 우측 정렬 그대로인지
- [ ] 글 페이지 상단의 "ADVERTISEMENT" 라벨이 사라졌는지

---
_Generated by [Claude Code](https://claude.ai/code/session_01LF1EU4iJTskuyeJjmGLvVP)_