### PR TITLE
Generate unique card thumbnails from title-derived seed

### DIFF
--- a/_includes/postbox.html
+++ b/_includes/postbox.html
@@ -1,6 +1,17 @@
+{% comment %} Deterministic color seed derived from title + url + date {% endcomment %}
+{% assign t_len = post.title | size %}
+{% assign u_len = post.url | size %}
+{% assign d_day = post.date | date: '%j' | plus: 0 %}
+{% assign d_yr = post.date | date: '%y' | plus: 0 %}
+{% assign seed = t_len | times: 53 | plus: u_len | times: 11 | plus: d_day | times: 7 | plus: d_yr %}
+{% assign hue = seed | modulo: 360 %}
+{% assign hue2 = hue | plus: 35 | modulo: 360 %}
+{% assign angle = seed | modulo: 8 | times: 22 | plus: 130 %}
+{% assign initials = post.title | strip | slice: 0, 2 | upcase %}
+
 <article class="post-card">
   <a href="{{ site.baseurl }}{{ post.url }}" aria-label="{{ post.title }}">
-    <div class="post-card-thumb">
+    <div class="post-card-thumb"{% unless post.image %} style="background:linear-gradient({{ angle }}deg, hsl({{ hue }}, 68%, 58%), hsl({{ hue2 }}, 72%, 44%));"{% endunless %}>
       {% if post.image %}
         {% if post.image contains "://" %}
           <img src="{{ post.image }}" alt="{{ post.title }}" loading="lazy">
@@ -8,7 +19,7 @@
           <img src="{{ site.baseurl }}/{{ post.image }}" alt="{{ post.title }}" loading="lazy">
         {% endif %}
       {% else %}
-        {{ post.title | slice: 0, 1 | upcase }}
+        <span class="post-card-initials">{{ initials }}</span>
       {% endif %}
     </div>
     <div class="post-card-body">

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -393,11 +393,32 @@ pre code {
   aspect-ratio: 16 / 9;
   background: linear-gradient(135deg, var(--accent-soft), transparent);
   display: flex; align-items: center; justify-content: center;
-  color: var(--accent);
+  color: #fff;
   font-weight: 800;
-  font-size: 1.6rem;
+  font-size: 2rem;
+  letter-spacing: -0.02em;
+  position: relative;
+  overflow: hidden;
 }
-.post-card-thumb img { width: 100%; height: 100%; object-fit: cover; }
+.post-card-thumb::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image:
+    radial-gradient(circle at 20% 30%, rgba(255,255,255,0.18) 0, transparent 40%),
+    radial-gradient(circle at 80% 70%, rgba(0,0,0,0.18) 0, transparent 50%);
+  pointer-events: none;
+}
+.post-card-thumb img {
+  width: 100%; height: 100%; object-fit: cover;
+  position: relative; z-index: 1;
+}
+.post-card-initials {
+  position: relative;
+  z-index: 1;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.18);
+  font-feature-settings: "tnum" 1;
+}
 
 .post-card-body { padding: 18px 20px 16px; flex: 1; display: flex; flex-direction: column; }
 .post-card-cats {


### PR DESCRIPTION
## Summary

모든 글이 `image:` front matter가 없어 카드 썸네일이 동일한 색에 첫 글자 하나만 표시되던 문제를 해결.

### 변경
- 제목 길이 + URL 길이 + 발행일(day-of-year, year)을 시드로 결합 → HSL 두 색상 + 각도 산출
- 같은 글은 항상 같은 그라디언트, 글이 다르면 다른 색
- 첫 글자 1개 → **첫 글자 2개**로 변경
- 그라디언트 위에 부드러운 라이트/섀도 라디얼 오버레이 추가로 깊이감
- `image:`가 있는 글은 기존 동작 그대로 유지

별도 이미지 자산 추가 없이 카드 그리드가 컬러풀하게 변합니다.

## Test plan
- [ ] 홈 카드들이 글마다 서로 다른 색 그라디언트로 표시되는지
- [ ] 같은 글을 새로고침해도 같은 색이 유지되는지
- [ ] 첫 글자 2개가 흰색으로 가운데 정렬되어 잘 보이는지

---
_Generated by [Claude Code](https://claude.ai/code/session_01LF1EU4iJTskuyeJjmGLvVP)_