### PR TITLE
Color and label card thumbs by category instead of title

### DIFF
--- a/_includes/postbox.html
+++ b/_includes/postbox.html
@@ -1,17 +1,33 @@
-{% comment %} Deterministic color seed derived from title + url + date {% endcomment %}
-{% assign t_len = post.title | size %}
-{% assign u_len = post.url | size %}
-{% assign d_day = post.date | date: '%j' | plus: 0 %}
-{% assign d_yr = post.date | date: '%y' | plus: 0 %}
-{% assign seed = t_len | times: 53 | plus: u_len | times: 11 | plus: d_day | times: 7 | plus: d_yr %}
-{% assign hue = seed | modulo: 360 %}
-{% assign hue2 = hue | plus: 35 | modulo: 360 %}
-{% assign angle = seed | modulo: 8 | times: 22 | plus: 130 %}
-{% assign initials = post.title | strip | slice: 0, 2 | upcase %}
+{% comment %} Pick the most specific category (last one) for color/label {% endcomment %}
+{% assign primary = post.categories | last | default: post.categories | first | default: 'general' %}
+{% assign key = primary | downcase %}
+
+{% comment %} Hue mapping for known categories, hashed fallback otherwise {% endcomment %}
+{% case key %}
+  {% when 'design-patterns' %}{% assign hue = 278 %}
+  {% when 'refactoring' %}{% assign hue = 22 %}
+  {% when 'spring-security' %}{% assign hue = 142 %}
+  {% when 'spring-camp' %}{% assign hue = 158 %}
+  {% when 'mongodb' %}{% assign hue = 100 %}
+  {% when 'python' %}{% assign hue = 48 %}
+  {% when 'flask' %}{% assign hue = 32 %}
+  {% when 'angular2' %}{% assign hue = 358 %}
+  {% when 'docker' %}{% assign hue = 205 %}
+  {% when 'jekyll' %}{% assign hue = 340 %}
+  {% when 'mac' %}{% assign hue = 200 %}
+  {% when 'study' %}{% assign hue = 225 %}
+  {% else %}
+    {% assign k_size = key | size %}
+    {% assign hue = k_size | times: 47 | plus: 17 | modulo: 360 %}
+{% endcase %}
+
+{% assign hue2 = hue | plus: 32 | modulo: 360 %}
+{% assign angle = key | size | times: 13 | modulo: 8 | times: 22 | plus: 130 %}
+{% assign display_cat = primary | replace: '-', ' ' | upcase %}
 
 <article class="post-card">
   <a href="{{ site.baseurl }}{{ post.url }}" aria-label="{{ post.title }}">
-    <div class="post-card-thumb"{% unless post.image %} style="background:linear-gradient({{ angle }}deg, hsl({{ hue }}, 68%, 58%), hsl({{ hue2 }}, 72%, 44%));"{% endunless %}>
+    <div class="post-card-thumb"{% unless post.image %} style="background:linear-gradient({{ angle }}deg, hsl({{ hue }}, 68%, 56%), hsl({{ hue2 }}, 72%, 42%));"{% endunless %}>
       {% if post.image %}
         {% if post.image contains "://" %}
           <img src="{{ post.image }}" alt="{{ post.title }}" loading="lazy">
@@ -19,7 +35,7 @@
           <img src="{{ site.baseurl }}/{{ post.image }}" alt="{{ post.title }}" loading="lazy">
         {% endif %}
       {% else %}
-        <span class="post-card-initials">{{ initials }}</span>
+        <span class="post-card-cat-label">{{ display_cat }}</span>
       {% endif %}
     </div>
     <div class="post-card-body">

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -413,10 +413,17 @@ pre code {
   width: 100%; height: 100%; object-fit: cover;
   position: relative; z-index: 1;
 }
-.post-card-initials {
+.post-card-cat-label {
   position: relative;
   z-index: 1;
-  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.18);
+  font-size: clamp(1.05rem, 3.6vw, 1.7rem);
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  line-height: 1.15;
+  text-align: center;
+  padding: 0 18px;
+  word-break: keep-all;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.22);
   font-feature-settings: "tnum" 1;
 }
 


### PR DESCRIPTION
## Summary

카드 썸네일이 제목 첫 글자 + 제목 기반 색상이 아니라, **카테고리 기반 색상 + 카테고리 이름 텍스트**가 되도록 변경.

### 변경 내용
- 같은 카테고리 글들은 모두 동일한 색상으로 묶임 (시각적 그루핑 효과)
- 주요 카테고리는 의미 있는 색으로 하드 매핑:
  - design-patterns → 보라
  - refactoring → 오렌지
  - spring-security / spring-camp → 그린 계열
  - mongodb → 라임
  - python → 옐로우
  - flask → 앰버
  - angular2 → 레드
  - docker → 블루
  - jekyll → 핑크
  - mac → 블루그레이
  - study → 인디고
- 미정의 카테고리는 카테고리 이름 길이 해시로 자동 색 부여
- 썸네일에 카테고리 이름 큰 글씨로 표시 (`DESIGN PATTERNS`, `MONGODB` 등)
- 폰트는 `clamp()`로 화면 크기 따라 자동 조정

## Test plan
- [ ] 같은 카테고리 글은 같은 색
- [ ] 카테고리 이름이 잘리지 않고 카드 안에 깔끔히 표시
- [ ] 모바일/데스크탑 모두에서 폰트 크기 자연스러운지

---
_Generated by [Claude Code](https://claude.ai/code/session_01LF1EU4iJTskuyeJjmGLvVP)_