### PR TITLE
Reduce new-post front matter to just `title:`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,57 @@
-# Memoirs Jekyll Theme
+# niee.blog
 
-[Live Demo](https://wowthemesnet.github.io/jekyll-theme-memoirs/) | [Docs & Download](https://bootstrapstarter.com/bootstrap-templates/jekyll-theme-memoirs/) |  [Buy me a coffee](https://www.wowthemes.net/donate/)
+개인 기술 블로그 (`https://parkminkyu.github.io`).
 
-![memoirs](https://bootstrapstarter.com/assets/img/themes/memoirs-jekyll.jpg)
+## 새 글 쓰기
+
+가장 간단한 방법은 두 가지입니다.
+
+### 1. 스크립트로 한 번에 만들기 (로컬)
+
+```bash
+./bin/new-post.sh "글 제목"
+./bin/new-post.sh "Python Flask 시작하기" python,flask
+```
+
+스크립트가 `_posts/YYYY-MM-DD-slug.md`를 생성하고 에디터를 열어줍니다.
+이후 본문을 쓰고 `git add . && git commit -m "..." && git push`.
+
+### 2. GitHub 웹에서 바로 만들기
+
+1. https://github.com/ParkMinKyu/ParkMinKyu.github.io 접속
+2. `_posts/` 폴더 → **Add file** → **Create new file**
+3. 파일명: `2026-04-28-내-글-제목.md`
+4. 아래 템플릿 붙여넣고 작성 후 **Commit changes**.
+
+## 최소 front matter
+
+```markdown
+---
+title: 글 제목
+---
+
+본문을 마크다운으로 작성합니다.
+```
+
+`author`, `layout`, `date`(파일명에서 자동)는 `_config.yml`의 defaults에서
+자동 채워지므로 적지 않아도 됩니다. 카테고리/태그가 필요하면 다음을 추가:
+
+```markdown
+---
+title: 글 제목
+category: [python, flask]
+tags: ["python", "tip"]
+---
+```
+
+## 로컬 미리보기 (선택)
+
+```bash
+bundle install
+bundle exec jekyll serve --livereload
+# http://localhost:4000
+```
+
+## 라이센스
+
+콘텐츠는 별도 명시가 없는 한 운영자 개인 저작물입니다.

--- a/_config.yml
+++ b/_config.yml
@@ -39,9 +39,23 @@ jekyll-archives:
   permalinks:
     category: '/category/:name/'
     
-# Pagination 
+# Pagination
 paginate: 6
 paginate_path: /page:num/
+
+# Front matter defaults (so new posts only need `title:`)
+defaults:
+  - scope:
+      path: ""
+      type: "posts"
+    values:
+      layout: "post"
+      author: "niee"
+  - scope:
+      path: "_pages"
+      type: "pages"
+    values:
+      layout: "page"
     
 # Other
 highlighter: none

--- a/bin/new-post.sh
+++ b/bin/new-post.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# bin/new-post.sh — Create a new Jekyll post with minimum boilerplate.
+#
+# Usage:
+#   ./bin/new-post.sh "글 제목"
+#   ./bin/new-post.sh "글 제목" python,flask     # optional category list
+#
+# The script writes _posts/YYYY-MM-DD-slug.md with just `title:` in the
+# front matter (everything else is filled in via _config.yml defaults).
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 \"글 제목\" [category1,category2]" >&2
+  exit 1
+fi
+
+TITLE="$1"
+CATS="${2:-}"
+DATE=$(date +%Y-%m-%d)
+
+# Slug: lowercase, replace spaces with hyphens, drop most punctuation
+SLUG=$(echo "$TITLE" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed -E 's/[^[:alnum:][:space:]가-힣ㄱ-ㅎㅏ-ㅣ-]+//g' \
+  | sed -E 's/[[:space:]]+/-/g' \
+  | sed -E 's/-+/-/g' \
+  | sed -E 's/^-|-$//g')
+
+if [ -z "$SLUG" ]; then
+  SLUG="post"
+fi
+
+ROOT_DIR=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+FILE="$ROOT_DIR/_posts/$DATE-$SLUG.md"
+
+if [ -e "$FILE" ]; then
+  echo "이미 존재합니다: $FILE" >&2
+  exit 1
+fi
+
+{
+  echo "---"
+  echo "title: $TITLE"
+  if [ -n "$CATS" ]; then
+    echo "category: [${CATS//,/, }]"
+  fi
+  echo "---"
+  echo
+  echo "여기에 본문을 작성하세요."
+} > "$FILE"
+
+echo "생성됨: $FILE"
+
+# Try to open in the user's editor
+if [ -n "${EDITOR:-}" ]; then
+  "$EDITOR" "$FILE"
+elif command -v code >/dev/null 2>&1; then
+  code "$FILE"
+fi


### PR DESCRIPTION
## Summary

새 글 작성 시 매번 적어야 했던 front matter를 거의 다 자동 처리. 이제 새 글은 사실상 `title:` 한 줄만 적으면 됩니다.

### 변경
- `_config.yml`에 `defaults` 추가
  - `_posts` → `layout: post`, `author: niee` 자동 적용
  - `_pages` → `layout: page` 자동 적용
- `bin/new-post.sh` 스크립트 추가
  - 사용법: `./bin/new-post.sh "글 제목"` 또는 `./bin/new-post.sh "글 제목" python,flask`
  - 파일명/날짜/슬러그/front matter 자동 생성, `$EDITOR`로 자동 오픈
- README 재작성 — 새 글 쓰는 두 가지 방법(스크립트, GitHub 웹) 안내

### 결과: 글 한 편 쓰는 데 필요한 최소 front matter

```markdown
---
title: 제목
---

본문
```

date는 파일명에서, layout/author는 defaults에서 자동.

## Test plan
- [ ] 기존 글이 모두 정상 빌드되는지 (front matter에 layout/author가 있어도 defaults와 충돌 없음)
- [ ] 새 글 하나 시험 작성 시 `title:`만으로 정상 게시되는지
- [ ] `./bin/new-post.sh` 동작 확인

---
_Generated by [Claude Code](https://claude.ai/code/session_01LF1EU4iJTskuyeJjmGLvVP)_