### PR TITLE
Auto-prefix today's date to undated posts

### DIFF
--- a/.github/workflows/auto-date-posts.yml
+++ b/.github/workflows/auto-date-posts.yml
@@ -1,0 +1,46 @@
+name: Auto-prefix dates on new posts
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - '_posts/**.md'
+      - '_posts/**.markdown'
+
+permissions:
+  contents: write
+
+jobs:
+  rename:
+    runs-on: ubuntu-latest
+    if: github.actor != 'github-actions[bot]'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Prefix today's date to posts that lack one
+        id: rename
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          changed=0
+          today=$(date -u +%Y-%m-%d)
+          for f in _posts/*.md _posts/*.markdown; do
+            base=$(basename "$f")
+            if [[ ! "$base" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}- ]]; then
+              new="_posts/${today}-${base}"
+              git mv "$f" "$new"
+              echo "renamed: $f -> $new"
+              changed=1
+            fi
+          done
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push if anything was renamed
+        if: steps.rename.outputs.changed == '1'
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git commit -m 'chore(posts): auto-prefix date to undated posts'
+          git push

--- a/README.md
+++ b/README.md
@@ -16,12 +16,17 @@
 스크립트가 `_posts/YYYY-MM-DD-slug.md`를 생성하고 에디터를 열어줍니다.
 이후 본문을 쓰고 `git add . && git commit -m "..." && git push`.
 
-### 2. GitHub 웹에서 바로 만들기
+### 2. GitHub 웹에서 바로 만들기 (날짜도 자동)
 
 1. https://github.com/ParkMinKyu/ParkMinKyu.github.io 접속
 2. `_posts/` 폴더 → **Add file** → **Create new file**
-3. 파일명: `2026-04-28-내-글-제목.md`
-4. 아래 템플릿 붙여넣고 작성 후 **Commit changes**.
+3. 파일명에 **날짜 없이** 그냥 제목만 적기: 예) `flask-debug-tips.md`
+4. 본문 작성 → **Commit changes**
+
+푸시되면 GitHub Actions가 자동으로 파일명 앞에 오늘 날짜를 붙여
+`2026-04-28-flask-debug-tips.md` 형태로 정리합니다. (`.github/workflows/auto-date-posts.yml`)
+
+날짜를 직접 지정하고 싶으면 `2026-05-01-제목.md` 처럼 그대로 적어도 됩니다.
 
 ## 최소 front matter
 


### PR DESCRIPTION
사용자 의도와 달라 닫음. URL에는 어차피 날짜가 들어가지 않으므로 (`permalink: /:title/`) 자동 prefix 워크플로 불필요. 운영자가 파일명 자체에 날짜가 보이는 것도 원치 않으면 별도로 Jekyll Collections 전환 검토 필요.