### PR TITLE
Fix all cards rendering as GENERAL due to broken default chain

### DIFF
--- a/_includes/postbox.html
+++ b/_includes/postbox.html
@@ -1,6 +1,9 @@
 {% comment %} Pick the most specific category (last one) for color/label {% endcomment %}
-{% assign primary = post.categories | last | default: post.categories | first | default: 'general' %}
-{% assign key = primary | downcase %}
+{% assign primary = 'general' %}
+{% if post.categories.size > 0 %}
+  {% assign primary = post.categories | last %}
+{% endif %}
+{% assign key = primary | downcase | strip %}
 
 {% comment %} Hue mapping for known categories, hashed fallback otherwise {% endcomment %}
 {% case key %}


### PR DESCRIPTION
## Summary

모든 카드 썸네일이 'GENERAL' 라벨로 표시되던 버그 수정.

### 원인
이전 코드:
```liquid
{% assign primary = post.categories | last | default: post.categories | first | default: 'general' %}
```

Liquid는 이걸 `((last | default: array) | first) | default: 'general'` 순으로 평가합니다. `| last`가 반환한 문자열에 `| first`가 적용되면서 nil이 되어, 결국 모든 글이 마지막 `default: 'general'`로 떨어졌습니다.

### 수정
명시적 if문으로 변환:
```liquid
{% assign primary = 'general' %}
{% if post.categories.size > 0 %}
  {% assign primary = post.categories | last %}
{% endif %}
```

추가로 키 매칭 전 `strip` 적용해 공백이 끼어든 경우도 방어.

## Test plan
- [ ] 카테고리가 있는 글들이 카테고리 이름과 색상으로 표시되는지 (PYTHON, MONGODB, DESIGN PATTERNS 등)
- [ ] 카테고리 없는 글만 GENERAL로 표시되는지
- [ ] 같은 카테고리 글들이 같은 색을 갖는지

---
_Generated by [Claude Code](https://claude.ai/code/session_01LF1EU4iJTskuyeJjmGLvVP)_